### PR TITLE
服务发现 服务异常时 使用缓存的数据

### DIFF
--- a/src/QueryFWrapper.php
+++ b/src/QueryFWrapper.php
@@ -60,11 +60,25 @@ class QueryFWrapper
                 $route['bTcp'] = $endpoint['istcp'];
                 $routeInfo[] = $route;
             }
-            $cacheInstance->setRouteInfo($id, $routeInfo);
+
+            if (count($routeInfo)>0){
+                $cacheInstance->setRouteInfo($id, $routeInfo);
+            }else {
+                if (isset($result['routeInfo'])) {
+                    $routeInfo = $result['routeInfo'];
+                }
+            }
 
             return $routeInfo;
         } catch (\Exception $e) {
-            throw $e;
+            $result = $cacheInstance->getRouteInfo($id);
+            if (isset($result['routeInfo'])) {
+                $routeInfo = $result['routeInfo'];
+                return $routeInfo;
+            }else{
+                throw $e;
+            }
+
         }
     }
 }


### PR DESCRIPTION
由于 当前 请求 tars.tarsregistry.QueryObj 服务 随机请求一个, 如果其中一个有异常 , 就会返回空.
改造成 返回 缓存数据. 达到高可用.